### PR TITLE
Patch to allow CakePHP apps running in subfolders

### DIFF
--- a/Controller/TwitterController.php
+++ b/Controller/TwitterController.php
@@ -71,7 +71,7 @@ class TwitterController extends AppController {
 		CakeSession::delete('Twitter.User');
 		if (!empty($this->consumerKey) && !empty($this->consumerSecret)) {
 			$this->Twitter->setupApp($this->consumerKey, $this->consumerSecret); 
-			$this->Twitter->connectApp('http://'.$_SERVER['HTTP_HOST'].'/twitter/twitter/authorization');
+			$this->Twitter->connectApp(Router::url(array('action' => 'authorization'), true));
 		} else {
 			echo 'App key and secret key are not set';
 			break;


### PR DESCRIPTION
The current `TwitterComponent->connect()` function establishes the URL very crudely, breaking the callback function for CakePHP apps running in sub-folders.

This change simply replaces the manual URL creation with a call to CakePHP's Router function, and asks for an absolute URL.
