### PR TITLE
Use Twitter API V1.1 as default

### DIFF
--- a/Lib/Utility/Twitter.php
+++ b/Lib/Utility/Twitter.php
@@ -186,7 +186,12 @@ class Twitter extends Object {
 /**
  * @param string $endPoint
  */
-	public function endPoint($endPoint, $apiVersion = '1', $ext = 'json') {
+	public function endPoint($endPoint, $apiVersion = false, $ext = 'json') {
+
+		if(!$apiVersion) {
+			$apiVersion = $this->_defaultApiVersion;
+		}
+
 		if (!in_array($endPoint, $this->_endPoints[$apiVersion])) {
 			throw new CakeException(__('Invalid Endpoint: %s', $endPoint));
 		}


### PR DESCRIPTION
Twitter Version 1 has been deprecated so I modified the library to use the variable $_defaultApiVersion as default which is currently set to V1.1
