### PR TITLE
Changes required for HTTPS only

### DIFF
--- a/Lib/Utility/Twitter.php
+++ b/Lib/Utility/Twitter.php
@@ -243,6 +243,7 @@ class Twitter extends Object {
 	public function connectApp($callbackUrl, $action='authorize') {
 		$request = array(
 			'uri' => array(
+				'scheme' => 'https',
 				'host' => 'api.twitter.com',
 				'path' => '/oauth/request_token',
 			),
@@ -256,7 +257,7 @@ class Twitter extends Object {
 		);
 		$response = $this->_Oauth->request($request);
 		parse_str($response, $response);
-		header("Location: http://api.twitter.com/oauth/$action?oauth_token={$response['oauth_token']}");
+		header("Location: https://api.twitter.com/oauth/$action?oauth_token={$response['oauth_token']}");
 		exit();
 	}
 
@@ -281,6 +282,7 @@ class Twitter extends Object {
 	public function authorizeTwitterUser($oauthToken, $oauthVerifier) {
 		$request = array(
 			'uri' => array(
+				'scheme' => 'https',
 				'host' => 'api.twitter.com',
 				'path' => '/oauth/access_token',
 				),
@@ -474,6 +476,7 @@ class Twitter extends Object {
 			$twitterMethodUrl = substr($twitterMethodUrl, 1, strlen($twitterMethodUrl));
 		}
 		$request['uri'] = array(
+			'scheme' => 'https',
 			'host' => 'api.twitter.com',
 			'path' => $twitterMethodUrl
 		);


### PR DESCRIPTION
This PR contains the changes necessary to work with Twitter's API after January 14th, 2014. Twitter now requires connections to be over HTTPS. The notice is here: https://dev.twitter.com/discussions/24239
