### PR TITLE
Fixed multibyte (utf-8) string tweet

### DIFF
--- a/Lib/Utility/Twitter.php
+++ b/Lib/Utility/Twitter.php
@@ -17,6 +17,7 @@
  */
 App::import('Vendor', 'Twitter.HttpSocketOauth');
 App::uses('CakeSession', 'Model/Datasource');
+App::uses('Multibyte', 'Utility');
 
 class Twitter extends Object {
 
@@ -486,9 +487,9 @@ class Twitter extends Object {
 		if (is_array($params)) {
 			$params = array_change_key_case($params);
 			if (array_key_exists('status', $params)) {
-				if (strlen($params['status']) > 140) $params['status'] = substr($params['status'], 0, 137) . '...';
+				if (mb_strlen($params['status']) > 140) $params['status'] = mb_substr($params['status'], 0, 137) . '...';
 			} else if (array_key_exists('text', $params)) {
-				if (strlen($params['text']) > 140) $params['text'] = substr($params['text'], 0, 137) . '...';
+				if (mb_strlen($params['text']) > 140) $params['text'] = mb_substr($params['text'], 0, 137) . '...';
 			}
 			if ($method == 'GET') {
 				$request['uri']['query'] = $params;


### PR DESCRIPTION
Substring 137 word tweet languages, But multibyte languages (utf-8) are splited "137 bytes". I fixed use CakePHP Multibyte core Utility class.

Below string is 178 bytes. This pull request successed below tweet. https://twitter.com/youkidearitai/status/654494558974181376

ハロウィンということでね、ちょっとね、てきとうなさいとのね、テストをしたくてですね。 #Arduino #iot #iotlt tekitoh-memdhoi.info/views/686
